### PR TITLE
Fix unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 	testImplementation 'org.springframework.security:spring-security-test'
+	testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
 }
 
 test {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+    username: sa
+    password: sa
+  liquibase:
+    change-log: classpath:/db/changelog/changelog-master.xml


### PR DESCRIPTION
The main @SpringBootTest has been failing since adding Liquibase. Add H2 database for tests, and a test-specific `application.yml` to use the H2 database during unit tests.